### PR TITLE
deprecation warning

### DIFF
--- a/ch06/ch06.py
+++ b/ch06/ch06.py
@@ -21,7 +21,7 @@ from sklearn.metrics import confusion_matrix
 from sklearn.metrics import precision_score, recall_score, f1_score
 from sklearn.metrics import make_scorer
 from sklearn.metrics import roc_curve, auc
-from scipy import interp
+from numpy import interp
 from sklearn.utils import resample
 
 # *Python Machine Learning 3rd Edition* by [Sebastian Raschka](https://sebastianraschka.com), Packt Publishing Ltd. 2019


### PR DESCRIPTION
DeprecationWarning: scipy.interp is deprecated and will be removed in SciPy 2.0.0, use numpy.interp instead